### PR TITLE
fix bug

### DIFF
--- a/libmlx/macos/interface.swift
+++ b/libmlx/macos/interface.swift
@@ -274,7 +274,7 @@ public func mlx_mouse_move_swift(_ winptr:UnsafeRawPointer, _ x:Int32, _ y:Int32
 ///	pt.y = sframe.size.y - frame.size.y - frame.origin.y + 1 + y
 	pt.y = frame.origin.y + frame.size.height - 1.0 - CGFloat(y)
 	CGWarpMouseCursorPosition(pt)
-	CGAssociateMouseAndMouseCursorPosition(Int32(1))
+	CGAssociateMouseAndMouseCursorPosition(1)
 	return Int32(0);
 }
 


### PR DESCRIPTION
fix #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified function call by removing unnecessary type conversion in mouse movement functionality for macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->